### PR TITLE
fix(filter): Prevent dragging when filtering without clicking rearrange

### DIFF
--- a/src/custom-sort.ts
+++ b/src/custom-sort.ts
@@ -242,7 +242,6 @@ export const addSortButton = function (
 			filterEl?.parentElement?.show();
 			filterEl?.focus();
 		}
-		plugin.app.workspace.trigger("file-explorer-draggable-change", value);
 	});
 	return sortEl;
 };


### PR DESCRIPTION
I'm not sure it is a feature or not, but I think the files should not be rearrangable when using `Filtering` without clicking `Rearrange`

![old](https://github.com/user-attachments/assets/4ae7e255-1f1c-4c3a-bd9b-6f3c662acdc4)

